### PR TITLE
changed clamps on wire_light and wire_lamp

### DIFF
--- a/lua/entities/gmod_wire_lamp.lua
+++ b/lua/entities/gmod_wire_lamp.lua
@@ -58,7 +58,7 @@ if CLIENT then
 		render.SetMaterial(light)
 
 		local color = self:GetColor()
-		color.a = math.Clamp((1000 - math.Clamp(distance, 32, 800)) * visdot, 0, 100)
+		color.a = math.Clamp((5000 - math.Clamp(distance, 32, 5000)) * visdot, 0, 100)
 
 		local size = math.Clamp(distance * visdot * (light_info.Scale or 2), 64, 512)
 		render.DrawSprite(lightpos, size, size, color)
@@ -99,11 +99,11 @@ function ENT:Switch(on)
 	flashlight:SetLocalAngles(light_info.Angle or angle_zero)
 	flashlight:SetKeyValue("enableshadows", 1)
 	flashlight:SetKeyValue("nearz", light_info.NearZ or 12)
-	flashlight:SetKeyValue("farz", singleplayer and self.Dist or math.Clamp(self.Dist, 64, 2048))
+	flashlight:SetKeyValue("farz", singleplayer and self.Dist or math.Clamp(self.Dist, 64, 5000))
 	flashlight:SetKeyValue("lightfov", singleplayer and self.FOV or math.Clamp(self.FOV, 10, 170))
 
 	local color = self:GetColor()
-	local brightness = singleplayer and self.Brightness or math.Clamp(self.Brightness, 0, 8)
+	local brightness = singleplayer and self.Brightness or math.Clamp(self.Brightness, 0, 100)
 	flashlight:SetKeyValue("lightcolor", Format("%i %i %i 255", color.r * brightness, color.g * brightness, color.b * brightness))
 	flashlight:Spawn()
 
@@ -121,9 +121,9 @@ function ENT:UpdateLight()
 	local singleplayer = game.SinglePlayer()
 	flashlight:Input("SpotlightTexture", NULL, NULL, self.Texture)
 	flashlight:Input("FOV", NULL, NULL, tostring(singleplayer and self.FOV or math.Clamp(self.FOV, 10, 170)))
-	flashlight:SetKeyValue("farz", singleplayer and self.Dist or math.Clamp(self.Dist, 64, 2048))
+	flashlight:SetKeyValue("farz", singleplayer and self.Dist or math.Clamp(self.Dist, 64, 5000))
 
-	local brightness = singleplayer and self.Brightness or math.Clamp(self.Brightness, 0, 8)
+	local brightness = singleplayer and self.Brightness or math.Clamp(self.Brightness, 0, 100)
 	flashlight:SetKeyValue("lightcolor", Format("%i %i %i 255", color.r * brightness, color.g * brightness, color.b * brightness))
 end
 

--- a/lua/entities/gmod_wire_light.lua
+++ b/lua/entities/gmod_wire_light.lua
@@ -227,15 +227,15 @@ function ENT:TriggerInput(iname, value)
 	elseif (iname == "RGB") then
 		self.R, self.G, self.B = math.Clamp(value[1],0,255), math.Clamp(value[2],0,255), math.Clamp(value[3],0,255)
 	elseif (iname == "GlowBrightness") then
-		if not game.SinglePlayer() then value = math.Clamp( value, 0, 10 ) end
+		if not game.SinglePlayer() then value = math.Clamp( value, 0, 100 ) end
 		self.brightness = value
 		self:SetBrightness( value )
 	elseif (iname == "GlowSize") then
-		if not game.SinglePlayer() then value = math.Clamp( value, 0, 1024 ) end
+		if not game.SinglePlayer() then value = math.Clamp( value, 0, 2048 ) end
 		self.size = value
 		self:SetSize( value )
 	elseif (iname == "SpriteSize") then
-		if not game.SinglePlayer() then value = math.Clamp( value, 0, 256 ) end
+		if not game.SinglePlayer() then value = math.Clamp( value, 0, 2560 ) end
 		self:SetSpriteSize( value )
 	end
 
@@ -254,9 +254,9 @@ function ENT:Setup(directional, radiant, glow, brightness, size, r, g, b, sprite
 	self.B = b or 255
 
 	if not game.SinglePlayer() then
-		self.brightness = math.Clamp( self.brightness, 0, 10 )
-		self.size = math.Clamp( self.size, 0, 1024 )
-		self.spritesize = math.Clamp( self.spritesize, 0, 256 )
+		self.brightness = math.Clamp( self.brightness, 0, 100 )
+		self.size = math.Clamp( self.size, 0, 2048 )
+		self.spritesize = math.Clamp( self.spritesize, 0, 2560 )
 	end
 
 	self:SetOn(startOn == nil or startOn)


### PR DESCRIPTION
lights
>changed max brightness to 100
>doubled max radius
>changed max sprite size to 2560 [even tho this number makes it seem big, it really isn't]

lamps
>same brightness as lights
>max distance increased

Since we moderate excessive use of lights already anyways, this shouldn't cause any problems. 
These changes are also not visible in the tool, making most people unaware.
Not like people many actually use wiremod lights or lamps..
Why increase brightness? The light effect stays longer on the props outside of the lights radius, allowing for niche effects.
Think of it as 0.1s longer for each brightness level increase.